### PR TITLE
Change Order Status Color

### DIFF
--- a/src/constants/order.ts
+++ b/src/constants/order.ts
@@ -4,9 +4,9 @@ export const ORDER_STATUS = {
   2: {
     label: "Order Accepted by Supplier",
     value: 2,
-    color: "primary",
+    color: "secondary",
   },
-  3: { label: "Order Ready", value: 3, color: "success" },
+  3: { label: "Order Ready", value: 3, color: "primary" },
   4: { label: "Order in Transit", value: 4, color: "warning" },
   5: { label: "Order Delivered", value: 5, color: "success" },
 } as const;


### PR DESCRIPTION
**Change**
- Change the order status color to be a different color between 'Order Delivered' and 'Order Ready'

**Preview**

![Screenshot 2024-11-23 at 12 27 25 AM](https://github.com/user-attachments/assets/94a00813-c611-4f81-a846-3a01f1572f9e)
![Screenshot 2024-11-23 at 12 27 10 AM](https://github.com/user-attachments/assets/65937f97-7a94-43f8-a01e-cd3f891eb755)
